### PR TITLE
解决下载文件只有30字节的问题

### DIFF
--- a/MDAT-DEV/src/main/java/Dao/MssqlDao.java
+++ b/MDAT-DEV/src/main/java/Dao/MssqlDao.java
@@ -524,7 +524,7 @@ public class MssqlDao {
                 "set @alllines = @alllines + @line + '\n'\n" +
                 "exec @ret = sp_oamethod @f, 'readline', @line out\n" +
                 "end\n" +
-                "select distinct convert(varbinary, @alllines) as lines";
+                "select distinct convert(varbinary(max), @alllines) as lines";
         sql = String.format(sql,path);
         try {
             stmt = CONN.createStatement();


### PR DESCRIPTION
varbinary默认只有30，这里应该改成varbinary(max)