### PR TITLE
fix: 针对Oracle 11gR2 Enterprise做了一点优化，应该不影响新版本的Oracle（太忙了没时间搭环境了）

### DIFF
--- a/MDAT-DEV/src/main/Plugins/Oracle/ShellUtil.java
+++ b/MDAT-DEV/src/main/Plugins/Oracle/ShellUtil.java
@@ -1,6 +1,6 @@
 import java.io.*;
 import java.net.Socket;
-import java.util.concurrent.RecursiveTask;
+//import java.util.concurrent.RecursiveTask;
 
 public class ShellUtil extends Object{
     public static String run(String methodName, String params, String encoding) {

--- a/MDAT-DEV/src/main/java/Util/OracleSqlUtil.java
+++ b/MDAT-DEV/src/main/java/Util/OracleSqlUtil.java
@@ -15,7 +15,7 @@ public class OracleSqlUtil {
     public static String ShellUtilGRANT_JAVA_EXECSql = "begin dbms_java.grant_permission( 'PUBLIC', 'SYS:java.io.FilePermission', '<<ALL FILES>>', 'read,write,execute,delete' );end;";
     public static String ShellUtilGRANT_JAVA_EXEC2Sql = "begin dbms_java.grant_permission('PUBLIC','SYS:java.lang.RuntimePermission', '*', '');end;";
     public static String ShellUtilGRANT_JAVA_EXEC3Sql = "begin dbms_java.grant_permission('PUBLIC','SYS:java.net.SocketPermission', '*', 'accept, connect, listen, resolve');end;";
-    public static String ShellUtilCREATE_FUNCTIONSql = "create or replace function shellrun(methodName varchar2,params varchar2,encoding varchar2) return varchar2 as language java name 'ShellUtil.run(java.lang.String,java.lang.String,java.lang.String) return java.lang.String';";
+    public static String ShellUtilCREATE_FUNCTIONSql = "begin execute immediate 'create or replace function shellrun(methodName varchar2,params varchar2,encoding varchar2) return varchar2 as language java name ''ShellUtil.run(java.lang.String,java.lang.String,java.lang.String) return java.lang.String'';';end;";
     public static String FileUtilCREATE_SOURCESql = "DECLARE v_command VARCHAR2(32767);BEGIN v_command :='create or replace and compile java source named \"FileUtil\" as %s';EXECUTE IMMEDIATE v_command;END;";
     public static String FileUtilGRANT_JAVA_EXECSql = "begin dbms_java.grant_permission( 'PUBLIC', 'SYS:java.io.FilePermission', '<<ALL FILES>>', 'read,write,execute,delete' );end;";
     public static String FileUtilGRANT_JAVA_EXEC1Sql = "begin dbms_java.grant_permission('PUBLIC', 'SYS:java.util.PropertyPermission', '*', 'read,write' );end;";


### PR DESCRIPTION
Oracle 11gR2 Enterprise 下创建数据库函数的时候会因为分号的语法问题导致最终的函数定义缺了个分号，这里采用匿名SQL块来缓解。另外ShellUtil源码中那个没用到的导入语句也会影响Oracle 11g，先注释掉（可能需要在较新版本的Oracle上进行测试）。